### PR TITLE
Fix bug in Queue implementation

### DIFF
--- a/data_structures/Queue.py
+++ b/data_structures/Queue.py
@@ -12,8 +12,7 @@ class Queue:
         return self.elements.pop()
 
     def is_empty(self):
-        if(self.length == 0):
-            return True
+        return self.length == 0
 
     def head(self):
         return self.elements[-1]
@@ -23,6 +22,7 @@ class Queue:
 
     def clear_queue(self):
         self.elements = []
+        self.length = 0
 
     def __len__(self):
         return self.length
@@ -38,11 +38,4 @@ class Queue:
 
 
 
-cola = Queue()
-cola.enqueue(1)
-cola.enqueue(2)
-cola.enqueue(3)
-print(cola)
-print(cola.dequeue())
-print(cola)
 

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -1,0 +1,24 @@
+import unittest
+from data_structures.Queue import Queue
+
+class TestQueue(unittest.TestCase):
+    def test_is_empty(self):
+        q = Queue()
+        self.assertTrue(q.is_empty())
+        q.enqueue(1)
+        self.assertFalse(q.is_empty())
+        q.clear_queue()
+        self.assertTrue(q.is_empty())
+
+    def test_enqueue_dequeue(self):
+        q = Queue()
+        q.enqueue('a')
+        q.enqueue('b')
+        self.assertEqual(len(q), 2)
+        self.assertEqual(q.dequeue(), 'a')
+        self.assertEqual(len(q), 1)
+        self.assertEqual(q.dequeue(), 'b')
+        self.assertTrue(q.is_empty())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `Queue.is_empty` logic and clear_queue length reset
- remove example usage from `Queue` module
- add unit tests for the queue

## Testing
- `python -m pytest test/test_queue.py -q`
- `python -m pytest test/sort_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683f561d1efc83248e8799810b55fd99