### PR TITLE
Add extensive unit tests

### DIFF
--- a/test/graph_traversal_test.py
+++ b/test/graph_traversal_test.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'graph_traversal_algorithms'))
+import BFS
+import DFS
+import dijkstra_algorithm
+import networkx as nx
+
+class TestGraphTraversal(unittest.TestCase):
+    def build_graph(self):
+        g = nx.Graph()
+        g.add_edge('A', 'B', weight=1)
+        g.add_edge('A', 'C', weight=5)
+        g.add_edge('B', 'C', weight=2)
+        g.add_edge('C', 'D', weight=1)
+        return g
+
+    def test_bfs(self):
+        g = self.build_graph()
+        order = BFS.BFS(g, 'A')
+        self.assertEqual(order, ['A', 'B', 'C', 'D'])
+
+    def test_dfs(self):
+        g = self.build_graph()
+        order = DFS.DFS(g, 'A')
+        self.assertEqual(order[0], 'A')
+        self.assertEqual(set(order), {'A', 'B', 'C', 'D'})
+
+    def test_dijkstra(self):
+        g = self.build_graph()
+        path = dijkstra_algorithm.dijkstra(g, 'A', 'D')
+        self.assertEqual(path, ['A', 'B', 'C', 'D'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_double_linked_list.py
+++ b/test/test_double_linked_list.py
@@ -1,0 +1,17 @@
+import unittest
+from data_structures.double_linked_list import DoubleLinkedList
+
+class TestDoubleLinkedList(unittest.TestCase):
+    def test_add_and_remove(self):
+        dl = DoubleLinkedList(1)
+        dl.add_node(2)
+        dl.add_node(3)
+        self.assertEqual(str(dl), '1 <-> 2 <-> 3')
+        removed = dl.remove_node_by_position(1)
+        self.assertEqual(removed, 2)
+        self.assertEqual(len(dl), 2)
+        self.assertEqual(str(dl), '1 <-> 3')
+        self.assertEqual(dl.find_node_by_position(1).value, 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_linked_list.py
+++ b/test/test_linked_list.py
@@ -1,0 +1,21 @@
+import unittest
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'data_structures'))
+import linked_list
+
+class TestLinkedList(unittest.TestCase):
+    def test_operations(self):
+        ll = linked_list.Simple_Linked_List(1)
+        ll.add_node(2)
+        ll.add_node(3)
+        self.assertEqual(len(ll), 3)
+        self.assertEqual(str(ll), '1, 2, 3')
+        self.assertEqual(ll.find_node_by_position(1).value, 2)
+        ll.remove_node_by_position(1)
+        self.assertEqual(len(ll), 2)
+        self.assertEqual(str(ll), '1, 3')
+        self.assertEqual(ll.find_node_by_position(1).value, 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_search_algorithms.py
+++ b/test/test_search_algorithms.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'search algorithms'))
+from binary_search import binary_search
+from lineal_search import linear_search
+from fibonacci import fibonacci
+from binary_conversion import dec_to_binary
+from bisection_method import bisection_method
+from newton_raphson_method import newton_raphson
+from secant_method import secant_method
+
+class TestSearchAlgorithms(unittest.TestCase):
+    def test_linear_and_binary_search(self):
+        arr = [1, 2, 3, 4, 5]
+        self.assertEqual(linear_search(arr, 4), 3)
+        self.assertEqual(binary_search(arr, 4), 3)
+        self.assertEqual(binary_search([3,1,2], 2), -1)
+
+    def test_fibonacci(self):
+        self.assertEqual(fibonacci(5), 5)
+        self.assertEqual(fibonacci(1), 1)
+
+    def test_binary_conversion(self):
+        self.assertEqual(dec_to_binary(10), '1010')
+        self.assertEqual(dec_to_binary(0), '0')
+
+    def test_root_methods(self):
+        f = lambda x: x**2 - 4
+        self.assertAlmostEqual(bisection_method(f, 0, 3), 2, places=6)
+        self.assertAlmostEqual(secant_method(f, 1, 3), 2, places=6)
+        nr = newton_raphson(f, 1.0, 100)
+        self.assertAlmostEqual(nr, 2, places=6)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_stack.py
+++ b/test/test_stack.py
@@ -1,0 +1,20 @@
+import unittest
+from data_structures.stack import Stack
+
+class TestStack(unittest.TestCase):
+    def test_basic_operations(self):
+        s = Stack()
+        self.assertTrue(s.is_empty())
+        s.insert(1)
+        s.insert(2)
+        self.assertEqual(len(s), 2)
+        self.assertEqual(s.head(), 2)
+        self.assertEqual(s.tail(), 1)
+        self.assertEqual(repr(s), '1 ->2')
+        self.assertEqual(s.pop(), 2)
+        self.assertEqual(len(s), 1)
+        s.clear_stack()
+        self.assertTrue(s.is_empty())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_text_algorithms.py
+++ b/test/test_text_algorithms.py
@@ -1,0 +1,18 @@
+import unittest
+from text_algorithms.cesar_codex import cesar_codex
+from text_algorithms.vigenere_codex import vigenere_encrypt, vigenere_decrypt
+
+class TestTextAlgorithms(unittest.TestCase):
+    def test_cesar_codex(self):
+        self.assertEqual(cesar_codex('abc', 1), 'bcd')
+        self.assertEqual(cesar_codex('XYZ', 2), 'ZAB')
+
+    def test_vigenere(self):
+        message = 'HELLO WORLD'
+        key = 'KEY'
+        encrypted = vigenere_encrypt(message, key)
+        decrypted = vigenere_decrypt(encrypted, key)
+        self.assertEqual(decrypted, message)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for Stack, DoubleLinkedList and Simple_Linked_List
- test search algorithms such as binary/linear search, Fibonacci and numerical methods
- test graph traversal algorithms using NetworkX
- test cipher helpers

## Testing
- `python -m pytest -q test/test_stack.py test/test_double_linked_list.py test/test_linked_list.py test/test_search_algorithms.py test/graph_traversal_test.py test/test_queue.py test/sort_test.py test/genetic_algorithm_tests.py test/test_text_algorithms.py`

------
https://chatgpt.com/codex/tasks/task_e_683f593cae6483248e38e240a4c22741